### PR TITLE
Disable users search by e-mail

### DIFF
--- a/ckan/model/user.py
+++ b/ckan/model/user.py
@@ -291,8 +291,7 @@ class User(vdm.sqlalchemy.StatefulObjectMixin,
         filters = [
             cls.name.ilike(qstr),
             cls.fullname.ilike(qstr),
-            cls.openid.ilike(qstr),
-            cls.email.ilike(qstr)
+            cls.openid.ilike(qstr)
         ]
         # sysadmins can search on user emails
         import ckan.authz as authz


### PR DESCRIPTION
Disable users search by e-mail

Commit f6bc2080 allows to search users by e-mail. E-mails are private by
default so we shouldn't allow to search by them.